### PR TITLE
Make outputs linked into dependent projects automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ lib.property = ...;
 
 // Many properties are lists, and appending makes most sense.
 // += is overloaded to append individual items or {lists, of, items} to list properties
-lib.includePaths += "include";
+lib.includePaths += "lib/include";
 lib.includePaths += { "other_path", "third_path" };
 
 // "Features" are basically tags that are turned into appropriate compiler flags when compiling
@@ -97,11 +97,13 @@ lib.features += feature::DebugSymbols;
 lib.ext<extensions::Gcc>().compilerFlags += "-Wno-everything";
 
 // Projects have a set of exported properties that can be used by "consumers" of the project
-// For example, we want dependents to link with our static library output:
-lib.exports.libs += lib.output;
+// For example, we might want dependents to get the library's include path as well:
+lib.exports.includePaths += "lib/include";
 
 // A project that wants to use the library imports it. This applies all the
-// properties in its exports section.
+// properties in its exports section. It also adds a dependency link between
+// the projects so that output of the dependency is added to the linker input
+// of dependent projects.
 application.import(lib);
 
 // Bundles of project properties not attached to a project can also be created,

--- a/example/wilco.cpp
+++ b/example/wilco.cpp
@@ -32,11 +32,10 @@ void configure(Environment& env)
     helloPrinter.import(defaults);
     helloPrinter.files += env.listFiles("hellolib");
     helloPrinter.defines += "MESSAGE=" + str::quote(std::string(*arguments::printerMessage));
-    helloPrinter.exports.includePaths = "hellolib";
-    helloPrinter.exports.libs += helloPrinter.output;
+	helloPrinter.exports.includePaths = "hellolib";
 
-    Project& hello = env.createProject("Hello", Executable);
-    hello.import(defaults);
-    hello.import(helloPrinter); // Import adds all properties in the "exports" section of the imported project
+	Project& hello = env.createProject("Hello", Executable);
+	hello.import(defaults);
+	hello.import(helloPrinter); // Import adds all properties in the "exports" section of the imported project
     hello.files += env.listFiles("helloapp");
 }

--- a/wilco/core/project.h
+++ b/wilco/core/project.h
@@ -147,7 +147,24 @@ struct BuildSettings
         return extensionEntry->extensionData;
     }
 
-    /** Checks if an extension of type ExtensionType is present in this ProjectSettings. */
+	/** Fetches the extension of type ExtensionType in this ProjectSettings, adding it if it does not already exist. */
+	template <typename ExtensionType>
+	const ExtensionType& ext() const
+	{
+		// TODO: Better key, maybe? hash_code doesn't have to be unique.
+		auto key = typeid(ExtensionType).hash_code();
+
+		auto it = _extensions.find(key);
+		if (it != _extensions.end())
+		{
+			return static_cast<ExtensionEntryImpl<ExtensionType>*>(it->second.get())->extensionData;
+		}
+		auto extensionEntry = new ExtensionEntryImpl<ExtensionType>();
+		_extensions.insert({key, std::unique_ptr<ExtensionEntry>(extensionEntry)});
+		return extensionEntry->extensionData;
+	}
+
+	/** Checks if an extension of type ExtensionType is present in this ProjectSettings. */
     template<typename ExtensionType>
     bool hasExt() const
     {
@@ -184,8 +201,8 @@ private:
 
         ExtensionType extensionData;
     };
-    
-    std::map<size_t, std::unique_ptr<ExtensionEntry>> _extensions;
+
+	mutable std::map<size_t, std::unique_ptr<ExtensionEntry>> _extensions;
 };
 
 /**

--- a/wilco/modules/toolchain.h
+++ b/wilco/modules/toolchain.h
@@ -10,6 +10,20 @@
 
 struct ToolchainProvider;
 
+namespace extensions::internal
+{
+struct ToolchainOutputs
+{
+	ListPropertyValue<std::filesystem::path> objectFiles;
+	ListPropertyValue<std::filesystem::path> libraryFiles;
+
+	virtual void import(const ToolchainOutputs& other)
+	{
+		// These properties are used internally by toolchains and never imported
+	}
+};
+} // namespace extensions::internal
+
 struct Toolchains
 {
     static void install(ToolchainProvider* toolchain)
@@ -42,5 +56,5 @@ struct ToolchainProvider
         Toolchains::install(this);
     }
 
-    virtual std::vector<std::filesystem::path> process(Project& project, const std::filesystem::path& workingDir, const std::filesystem::path& dataDir) const = 0;
+	virtual void process(Project& project, const std::filesystem::path& workingDir, const std::filesystem::path& dataDir) const = 0;
 };

--- a/wilco/src/ninja.cpp
+++ b/wilco/src/ninja.cpp
@@ -1,4 +1,5 @@
 #include "actions/ninja.h"
+#include "modules/toolchain.h"
 #include "util/process.h"
 #include "buildconfigurator.h"
 #include "database.h"
@@ -127,22 +128,23 @@ static std::string emitProject(Environment& env, const std::filesystem::path& pr
         throw std::runtime_error("Command project '" + project.name + "' has no commands.");
     }
 
-    std::vector<std::string> projectOutputs;
-
-    const ToolchainProvider* toolchain = project.toolchain;
-    if(!toolchain)
+	const ToolchainProvider* toolchain = project.toolchain;
+	if(!toolchain)
     {
         toolchain = defaultToolchain;
     }
 
-    auto toolchainOutputs = toolchain->process(project, projectDir, dataDir);
-    for(auto& output : toolchainOutputs)
-    {
-        projectOutputs.push_back((pathOffset / output).string());
-    }
+	toolchain->process(project, projectDir, dataDir);
 
-    std::string prologue;
-    // TODO: Current isn't necessarily the host system
+	std::vector<std::string> projectOutputs;
+	const auto& toolchainOutputs = project.ext<extensions::internal::ToolchainOutputs>();
+	for (auto& output : toolchainOutputs.libraryFiles)
+	{
+		projectOutputs.push_back((pathOffset / output).string());
+	}
+
+	std::string prologue;
+	// TODO: Current isn't necessarily the host system
     if(OperatingSystem::current() == Windows)
     {
         prologue += "cmd /c ";

--- a/wilco/toolchains/cl.h
+++ b/wilco/toolchains/cl.h
@@ -58,5 +58,5 @@ struct ClToolchainProvider : public ToolchainProvider
     std::string getLinker(Project& project, std::filesystem::path pathOffset) const;
     std::string getCommonLinkerFlags(Project& project, std::filesystem::path pathOffset) const;
     std::string getLinkerFlags(Project& project, std::filesystem::path pathOffset, const std::vector<std::string>& inputs, const std::string& output) const;
-    std::vector<std::filesystem::path> process(Project& project, const std::filesystem::path& workingDir, const std::filesystem::path& dataDir) const override;
+	void process(Project& project, const std::filesystem::path& workingDir, const std::filesystem::path& dataDir) const override;
 };

--- a/wilco/toolchains/gcclike.h
+++ b/wilco/toolchains/gcclike.h
@@ -53,5 +53,5 @@ struct GccLikeToolchainProvider : public ToolchainProvider
     std::string getLinker(Project& project, std::filesystem::path pathOffset) const;
     std::string getCommonLinkerFlags(Project& project, Architecture arch, std::filesystem::path pathOffset) const;
     std::string getLinkerFlags(Project& project, Architecture arch, std::filesystem::path pathOffset, const std::vector<std::string>& inputs, const std::string& output) const;
-    std::vector<std::filesystem::path> process(Project& project, const std::filesystem::path& workingDir, const std::filesystem::path& dataDir) const override;
+	void process(Project& project, const std::filesystem::path& workingDir, const std::filesystem::path& dataDir) const override;
 };


### PR DESCRIPTION
Previously library projects had to export their outputs manually. They are now automatically added by the toolchain when processing the projects.